### PR TITLE
Fix lvl0 tag in docsearch strategy

### DIFF
--- a/src/scrapers/docssearch.ts
+++ b/src/scrapers/docssearch.ts
@@ -42,7 +42,7 @@ export default class DocsearchScaper {
       data.url = url
       const urls_tags = new URL(url).pathname.split('/')
       const only_urls_tags = urls_tags.slice(1, urls_tags.length - 1)
-      data.hierarchy_lvl0 = only_urls_tags[0]
+      data.hierarchy_lvl0 = only_urls_tags.join(' / ')
 
       const id = await elem.evaluate((el) => el.id)
       if (tag === 'H1') {


### PR DESCRIPTION
Lvl 0 tag required to display the category of a found document was possibly 0 if no category was found.


<img width="566" alt="Screenshot 2023-06-26 at 18 24 24" src="https://github.com/meilisearch/scrapix/assets/33010418/51091646-9a41-47aa-ae84-39fa0bac7863">

Additionally, the category is now created by splitting the path segments together
<img width="551" alt="Screenshot 2023-06-26 at 18 23 58" src="https://github.com/meilisearch/scrapix/assets/33010418/e5e1d5e2-3194-48f1-8877-840919411241">

