### PR TITLE
Run the crawler in the testing CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,6 +10,36 @@ on:
       - main
 
 jobs:
+  scrap_tests:
+    runs-on: ubuntu-latest
+    name: Crawler tests
+    services:
+      meilisearch:
+        image: getmeili/meilisearch:latest
+        env:
+          MEILI_MASTER_KEY: 'masterKey'
+          MEILI_NO_ANALYTICS: 'true'
+        ports:
+          - '7700:7700'
+    strategy:
+      fail-fast: false
+      matrix:
+        node: ['16', '18', '20']          
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup node
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node }}
+          cache: 'yarn'
+      - name: Install dependencies
+        run: yarn
+      - name: Run playground
+        run: yarn playground:start &
+      - name: Run default strategy scraper
+        run: yarn start -c misc/config_examples/docusaurus-default.json
+      - name: Run docsearch strategy scraper
+        run: yarn start -c misc/config_examples/docusaurus-docsearch.json
   lint_tests:
     runs-on: ubuntu-latest
     name: lint tests
@@ -18,7 +48,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 20
           cache: 'yarn'
       - name: Install dependencies
         run: yarn
@@ -32,7 +62,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 20
           cache: 'yarn'
       - name: Install dependencies
         run: yarn


### PR DESCRIPTION
While waiting for basic tests on the code side, this PR is meant to ensure the scraper process does not fail by throwing an error.

In the future, tests will be done to ensure that after the scraper ran, the meilisearch instance is correctly containing the indexes and their expected documents.