### PR TITLE
Add schema graph

### DIFF
--- a/src/scrapers/schema.ts
+++ b/src/scrapers/schema.ts
@@ -55,9 +55,15 @@ export default class SchemaScaper {
       })
     }
 
-    data.uid = uuidv4()
-
-    await this.sender.add(data)
+    if (data["@graph"]) {
+      for (const graph of data["@graph"]) {
+        graph.uid = uuidv4();
+        await this.sender.add(graph);
+      };
+    } else {
+      data.uid = uuidv4();
+      await this.sender.add(data);
+    }
   }
 
   _clean_schema(data: SchemaDocument) {

--- a/src/scrapers/schema.ts
+++ b/src/scrapers/schema.ts
@@ -55,14 +55,14 @@ export default class SchemaScaper {
       })
     }
 
-    if (data["@graph"]) {
-      for (const graph of data["@graph"]) {
-        graph.uid = uuidv4();
-        await this.sender.add(graph);
-      };
+    if (data['@graph']) {
+      for (const graph of data['@graph']) {
+        graph.uid = uuidv4()
+        await this.sender.add(graph)
+      }
     } else {
-      data.uid = uuidv4();
-      await this.sender.add(data);
+      data.uid = uuidv4()
+      await this.sender.add(data)
     }
   }
 

--- a/src/sender.ts
+++ b/src/sender.ts
@@ -44,7 +44,7 @@ export class Sender {
 
       await this.client.createIndex(this.index_uid, {
         primaryKey: this.config.primary_key || 'uid',
-      });
+      })
     } catch (e) {
       console.log('try to delete a tmp index if it exists')
     }
@@ -53,7 +53,7 @@ export class Sender {
   //Add a json object to the queue
   async add(data: DocumentType) {
     console.log('Sender::add')
-    if (this.config.primary_key && this.config.primary_key !== "uid") {
+    if (this.config.primary_key && this.config.primary_key !== 'uid') {
       delete data['uid']
     }
 

--- a/src/sender.ts
+++ b/src/sender.ts
@@ -41,29 +41,19 @@ export class Sender {
           await this.client.waitForTask(task.taskUid)
         }
       }
+
+      await this.client.createIndex(this.index_uid, {
+        primaryKey: this.config.primary_key || 'uid',
+      });
     } catch (e) {
       console.log('try to delete a tmp index if it exists')
-    }
-
-    if (this.config.primary_key) {
-      try {
-        await this.client
-          .index(this.index_uid)
-          .update({ primaryKey: this.config.primary_key })
-      } catch (e) {
-        console.log('try to create or update the index with the primary key')
-
-        await this.client.createIndex(this.index_uid, {
-          primaryKey: this.config.primary_key,
-        })
-      }
     }
   }
 
   //Add a json object to the queue
   async add(data: DocumentType) {
     console.log('Sender::add')
-    if (this.config.primary_key) {
+    if (this.config.primary_key && this.config.primary_key !== "uid") {
       delete data['uid']
     }
 


### PR DESCRIPTION
This pull request improves the schema scraper by taking into account the `@graph` object, which means the schema will not be describing one item (Product, Article) but multiple items. Taking this into account, it allows to create a new document per item and not one document for every item on the page. 

By doing this, I also saw that sometimes the index creation was not taking into account the right primary_key. I simplified the process to always send the primary_key (given on the config or `uid`) within the index creation. 