### PR TITLE
Simplify the way to get npm package version

### DIFF
--- a/src/meilisearch_client.ts
+++ b/src/meilisearch_client.ts
@@ -1,5 +1,4 @@
 import { Config, MeiliSearch } from 'meilisearch'
-import { PACKAGE_VERSION } from './package_version.js'
 
 export function initMeilisearchClient({
   host,
@@ -10,7 +9,7 @@ export function initMeilisearchClient({
     host,
     apiKey,
     clientAgents: [
-      `Meilisearch Crawler (v${PACKAGE_VERSION})`,
+      `Meilisearch Crawler (v${process.env.npm_package_version})`,
       ...clientAgents,
     ],
   })

--- a/src/package_version.ts
+++ b/src/package_version.ts
@@ -1,1 +1,0 @@
-export const PACKAGE_VERSION = '0.0.1'


### PR DESCRIPTION
This simple contribution uses the environment variable to get the npm package version instead of updating manually the version on a file. 

Not sure if it's working on Docker but it should as we are performing a npm run start and not a node index.js from a transpiled file. 