### PR TITLE
Add webhooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
-# Scrapix 
+# Scrapix
 This project is an API that will allow you to scrap any website and send the data to Meilisearch.
 
-This server have only one endpoint. 
+This server have only one endpoint.
 
 ## Endpoint
 ### POST /crawl
 This endpoint will crawl the website and send the data to Meilisearch.
-data: 
+data:
 ```json
 {
     "start_urls": ["https://www.google.com"],
@@ -38,14 +38,14 @@ data:
     "schema_settings": {
         "only_type": "Product", // Product, Article, etc...
         "convert_dates": true, // default false
-    },
+    }
 }
 ```
 
 ## Process
 ### 1. Add it to the queue
 While the server receive a crawling request it will add it to the queue. When the data is added to the queue it will return a response to the user.
-The queue is handle by redis ([Bull](https://github.com/OptimalBits/bull)). 
+The queue is handle by redis ([Bull](https://github.com/OptimalBits/bull)).
 The queue will dispatch the job to the worker.
 
 ### 2. Scrape the website
@@ -161,4 +161,31 @@ An array of user agents that are append at the end of the current user agents.
 In this case, if your `user_agents` value is `['My Thing (vx.x.x)']` the final `user_agent` becomes
 ```
 Meilisearch JS (vx.x.x); Meilisearch Crawler (vx.x.x); My Thing (vx.x.x)
+```
+
+## Webhooks
+
+To be able to receive updates on the state of the crawler, you need to create a webhook. To do so, you absolutely need to have a public URL that can be reached by the crawler. This URL will be called by the crawler to send you updates.
+
+To enable webhooks, you need add the following env vars.
+```txt
+WEBHOOK_URL=https://mywebsite.com/webhook
+WEBHOOK_TOKEN=mytoken
+WEBHOOK_INTERVAL=1000
+```
+
+- The `WEBHOOK_URL` is the URL that will be called by the crawler. The calls will be made with the `POST` method.
+- The `WEBHOOK_TOKEN` is a token string that will be used to sign the request. It will be used if present in the `Authorization` header of the request in the format `Authorization: Bearer ${token}`.
+- The `WEBHOOK_INTERVAL` is a way to change the frequency you want to receive updated from the scraper. The value is in milliseconds. The default value is 5000ms.
+
+Here is the Webhook payload:
+```json
+{
+  "date": "2022-01-01T12:34:56.000Z",
+  "meilisearch_url": "https://myproject.meilisearch.com",
+  "meilisearch_index_uid": "myindex",
+  "status": "active", // "added", "completed", "failed", "active", "wait", "delayed"
+  "nb_page_crawled": 20,
+  "nb_page_indexed": 15,
+}
 ```

--- a/README.md
+++ b/README.md
@@ -1,49 +1,55 @@
 # Scrapix
+
 This project is an API that will allow you to scrap any website and send the data to Meilisearch.
 
 This server have only one endpoint.
 
 ## Endpoint
+
 ### POST /crawl
+
 This endpoint will crawl the website and send the data to Meilisearch.
 data:
+
 ```json
 {
-    "start_urls": ["https://www.google.com"],
-    "urls_to_exclude": ["https://www.google.com"],
-    "urls_to_index": ["https://www.google.com"],
-    "urls_to_not_index": ["https://www.google.com"],
-    "meilisearch_url": "http://localhost:7700",
-    "meilisearch_api_key": "masterKey",
-    "meilisearch_index_uid": "google",
-    "stategy": "default", // docssearch, schema*, custom or default
-    "headless": true, // Open browser or not
-    "batch_size": 100, //null with send documents one by one
-    "primary_key": null,
-    "meilisearch_settings": {
-        "searchableAttributes": [
-            "h1",
-            "h2",
-            "h3",
-            "h4",
-            "h5",
-            "h6",
-            "p",
-            "title",
-            "meta.description",
-        ],
-        "filterableAttributes": ["urls_tags"],
-        "distinctAttribute": "url",
-    },
-    "schema_settings": {
-        "only_type": "Product", // Product, Article, etc...
-        "convert_dates": true, // default false
-    }
+  "start_urls": ["https://www.google.com"],
+  "urls_to_exclude": ["https://www.google.com"],
+  "urls_to_index": ["https://www.google.com"],
+  "urls_to_not_index": ["https://www.google.com"],
+  "meilisearch_url": "http://localhost:7700",
+  "meilisearch_api_key": "masterKey",
+  "meilisearch_index_uid": "google",
+  "stategy": "default", // docssearch, schema*, custom or default
+  "headless": true, // Open browser or not
+  "batch_size": 100, //null with send documents one by one
+  "primary_key": null,
+  "meilisearch_settings": {
+    "searchableAttributes": [
+      "h1",
+      "h2",
+      "h3",
+      "h4",
+      "h5",
+      "h6",
+      "p",
+      "title",
+      "meta.description"
+    ],
+    "filterableAttributes": ["urls_tags"],
+    "distinctAttribute": "url"
+  },
+  "schema_settings": {
+    "only_type": "Product", // Product, Article, etc...
+    "convert_dates": true // default false
+  }
 }
 ```
 
 ## Process
+
 ### 1. Add it to the queue
+
 While the server receive a crawling request it will add it to the queue. When the data is added to the queue it will return a response to the user.
 The queue is handle by redis ([Bull](https://github.com/OptimalBits/bull)).
 The queue will dispatch the job to the worker.
@@ -51,8 +57,10 @@ The queue will dispatch the job to the worker.
 ### 2. Scrape the website
 
 #### 2.1. Default strategy
+
 The worker will crawl the website by keeping only the page that have the same domain as urls given in parameters. It will not try to scrap the external links or files. It will also not try to scrape when pages are paginated pages (like `/page/1`).
 For each scrappable page it will scrape the data by trying to create blocks of titles and text. Each block will contains:
+
 - h1: The title of the block
 - h2: The sub title of the block
 - h3...h6: The sub sub title of the block
@@ -66,8 +74,10 @@ For each scrappable page it will scrape the data by trying to create blocks of t
 - url_tags: the url pathname split by / (array of string). The last element has been removed because it's the page name.
 
 #### 2.2. Docsearch strategy
+
 The worker will crawl the website by keeping only the page that have the same domain as urls given in parameters. It will not try to scrap the external links or files. It will also not try to scrape when pages are paginated pages (like `/page/1`).
 For each scrappable page it will scrape the data by trying to create blocks of titles and text. Each block will contains:
+
 - uid: a generated and incremental uid for the block
 - hierarchy_lvl0: the url pathname split by / (array of string). The last element has been removed because it's the page name.
 - hierarchy_lvl1: the h1 of the block
@@ -91,9 +101,10 @@ While the worker is scraping the website it will send the data to Meilisearch by
 Before sending the data to Meilisearch, it will create a new index called `{index_uid}_tmp`, apply the settings and add the data to it. Then it will use the index swap method to replace the old index by the new one. It will finish properly by deleting the tmp index.
 
 The setting applied:
+
 ```json
 {
-    "searchableAttributes": [
+  "searchableAttributes": [
     "h1",
     "h2",
     "h3",
@@ -102,10 +113,10 @@ The setting applied:
     "h6",
     "p",
     "title",
-    "meta.description",
-    ],
-    "filterableAttributes": ["urls_tags"],
-    "distinctAttribute": "url",
+    "meta.description"
+  ],
+  "filterableAttributes": ["urls_tags"],
+  "distinctAttribute": "url"
 }
 ```
 
@@ -136,10 +147,7 @@ Name of the index on which the content is indexed.
 
 `stategy`
 default: `default`
-Scraping strategy:
-    - `default` Scraps the content of webpages, it suits most use cases. It indexes the content in this format (show example)
-    - `docssearch` Scraps the content of webpages, it suits most use cases. The difference with the default strategy is that it indexes the content in a format compatible with docs-search bar
-    - `schema` Scraps the [`schema`](https://schema.org/) information of your web app.
+Scraping strategy: - `default` Scraps the content of webpages, it suits most use cases. It indexes the content in this format (show example) - `docssearch` Scraps the content of webpages, it suits most use cases. The difference with the default strategy is that it indexes the content in a format compatible with docs-search bar - `schema` Scraps the [`schema`](https://schema.org/) information of your web app.
 
 `headless`
 default: `true`
@@ -153,21 +161,26 @@ Your custom Meilisearch settings
 
 `schema_settings`
 If you strategy is `schema`:
-    `only_type`: Which types of schema should be parsed
-    `convert_dates`: If dates should be converted to timestamp. This is usefull to be able to order by date.
+`only_type`: Which types of schema should be parsed
+`convert_dates`: If dates should be converted to timestamp. This is usefull to be able to order by date.
 
 `user_agents`
 An array of user agents that are append at the end of the current user agents.
 In this case, if your `user_agents` value is `['My Thing (vx.x.x)']` the final `user_agent` becomes
+
 ```
 Meilisearch JS (vx.x.x); Meilisearch Crawler (vx.x.x); My Thing (vx.x.x)
 ```
+
+`webhook_payload`
+In the case [webhooks](#webhooks) are enabled, the webhook_payload option gives the possibility to provide information that will be added in the webhook payload.
 
 ## Webhooks
 
 To be able to receive updates on the state of the crawler, you need to create a webhook. To do so, you absolutely need to have a public URL that can be reached by the crawler. This URL will be called by the crawler to send you updates.
 
 To enable webhooks, you need add the following env vars.
+
 ```txt
 WEBHOOK_URL=https://mywebsite.com/webhook
 WEBHOOK_TOKEN=mytoken
@@ -179,6 +192,7 @@ WEBHOOK_INTERVAL=1000
 - The `WEBHOOK_INTERVAL` is a way to change the frequency you want to receive updated from the scraper. The value is in milliseconds. The default value is 5000ms.
 
 Here is the Webhook payload:
+
 ```json
 {
   "date": "2022-01-01T12:34:56.000Z",
@@ -186,6 +200,8 @@ Here is the Webhook payload:
   "meilisearch_index_uid": "myindex",
   "status": "active", // "added", "completed", "failed", "active", "wait", "delayed"
   "nb_page_crawled": 20,
-  "nb_page_indexed": 15,
+  "nb_page_indexed": 15
 }
 ```
+
+It is possible to add additional information in the webhook payload through the `webhook_payload` configuration

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "type": "module",
   "description": "This is an example of a Crawlee project.",
   "dependencies": {
+    "axios": "^1.4.0",
     "bull": "^4.10.4",
     "crawlee": "^3.0.0",
     "dotenv": "^16.0.3",

--- a/src/crawler.ts
+++ b/src/crawler.ts
@@ -26,8 +26,8 @@ export default class Crawler {
   urls: string[]
   scraper: Scraper
   crawler: PuppeteerCrawler
-  nb_page_crawled: number = 0
-  nb_page_indexed: number = 0
+  nb_page_crawled = 0
+  nb_page_indexed = 0
 
   constructor(sender: Sender, config: Config) {
     console.info('Crawler::constructor')
@@ -65,7 +65,7 @@ export default class Crawler {
   async run() {
     let interval = 5000
     if (process.env.WEBHOOK_INTERVAL) {
-      interval = parseInt(process.env.WEBHOOK_INTERVAL!)
+      interval = parseInt(process.env.WEBHOOK_INTERVAL)
     }
 
     const intervalId = setInterval(async () => {
@@ -74,13 +74,13 @@ export default class Crawler {
         nb_page_indexed: this.nb_page_indexed,
         nb_documents_sent: this.sender.nb_documents_sent,
       })
-    }, interval);
+    }, interval)
 
     await this.crawler.run(this.urls)
 
-    clearInterval(intervalId);
+    clearInterval(intervalId)
 
-    Webhook.get().active(this.config, {
+    await Webhook.get().active(this.config, {
       nb_page_crawled: this.nb_page_crawled,
       nb_page_indexed: this.nb_page_indexed,
       nb_documents_sent: this.sender.nb_documents_sent,

--- a/src/crawler_process.ts
+++ b/src/crawler_process.ts
@@ -11,8 +11,8 @@ async function startCrawling(config: Config) {
   const crawler = new Crawler(sender, config)
 
   await crawler.run()
-  await sender.finish()
-  await Webhook.get().completed(config)
+  const nbDocuments = await sender.finish()
+  await Webhook.get().completed(config, nbDocuments)
 }
 
 // Listen for messages from the parent thread

--- a/src/crawler_process.ts
+++ b/src/crawler_process.ts
@@ -1,8 +1,10 @@
 import { Sender } from './sender.js'
 import Crawler from './crawler.js'
 import { Config } from './types.js'
+import { Webhook } from './webhook.js'
 
 async function startCrawling(config: Config) {
+  await Webhook.get().started(config)
   const sender = new Sender(config)
   await sender.init()
 
@@ -10,6 +12,7 @@ async function startCrawling(config: Config) {
 
   await crawler.run()
   await sender.finish()
+  await Webhook.get().completed(config)
 }
 
 // Listen for messages from the parent thread

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,9 +4,10 @@ dotenv.config()
 import fs from 'fs'
 import yargs from 'yargs'
 import { hideBin } from 'yargs/helpers'
-import { Sender } from './sender.js'
 import Crawler from './crawler.js'
+import { Sender } from './sender.js'
 import { Config } from './types.js'
+import { Webhook } from './webhook.js'
 
 // Parse command line arguments and get a configuration file path
 const argv = await yargs(hideBin(process.argv)).option('config', {
@@ -20,6 +21,8 @@ const config: Config = JSON.parse(
   fs.readFileSync(argv.config, { encoding: 'utf-8' })
 ) as Config
 
+await Webhook.get().started(config)
+
 const sender = new Sender(config)
 await sender.init()
 
@@ -27,3 +30,4 @@ const crawler = new Crawler(sender, config)
 
 await crawler.run()
 await sender.finish()
+await Webhook.get().completed(config)

--- a/src/sender.ts
+++ b/src/sender.ts
@@ -90,6 +90,8 @@ export class Sender {
       const task = await this.client.deleteIndex(this.index_uid)
       await this.client.index(this.index_uid).waitForTask(task.taskUid)
     }
+
+    return this.nb_documents_sent
   }
 
   async __batchSend() {

--- a/src/sender.ts
+++ b/src/sender.ts
@@ -5,15 +5,15 @@ import { initMeilisearchClient } from './meilisearch_client.js'
 //Create a class called Sender that will queue the json data and batch it to a Meilisearch instance
 export class Sender {
   config: Config
-  queue: DocumentType[]
+  queue: DocumentType[] = []
   initial_index_uid: string
   index_uid: string
   batch_size: number
   client: MeiliSearch
+  nb_documents_sent: number = 0
 
   constructor(config: Config) {
     console.info('Sender::constructor')
-    this.queue = []
     this.config = config
     this.initial_index_uid = config.meilisearch_index_uid
     this.index_uid = this.initial_index_uid
@@ -62,6 +62,8 @@ export class Sender {
 
   //Add a json object to the queue
   async add(data: DocumentType) {
+    this.nb_documents_sent++
+
     console.log('Sender::add')
     if (this.config.primary_key) {
       delete data['uid']

--- a/src/sender.ts
+++ b/src/sender.ts
@@ -10,7 +10,7 @@ export class Sender {
   index_uid: string
   batch_size: number
   client: MeiliSearch
-  nb_documents_sent: number = 0
+  nb_documents_sent = 0
 
   constructor(config: Config) {
     console.info('Sender::constructor')

--- a/src/server.ts
+++ b/src/server.ts
@@ -5,6 +5,7 @@ import express from 'express'
 import TaskQueue from './taskQueue.js'
 import { Sender } from './sender.js'
 import Crawler from './crawler.js'
+import { Webhook } from './webhook.js'
 
 const port = process.env.PORT || 8080
 
@@ -13,16 +14,38 @@ class Server {
   app: express.Application
 
   constructor() {
+    this.__check_env()
+
     this.taskQueue = new TaskQueue()
     this.app = express()
     this.app.use(express.json())
     this.app.post('/crawl', this.__asyncCrawl.bind(this))
     this.app.post('/crawl/async', this.__asyncCrawl.bind(this))
     this.app.post('/crawl/sync', this.__syncCrawl.bind(this))
+    this.app.post('/webhook', this.__log_webhook.bind(this))
 
     this.app.listen(port, () =>
       console.log(`Example app listening on port ${port}!`)
     )
+  }
+
+  __check_env() {
+    const {
+      REDIS_URL,
+      WEBHOOK_URL,
+      WEBHOOK_TOKEN,
+      WEBHOOK_INTERVAL
+    } = process.env;
+
+    console.log('REDIS_URL: ', REDIS_URL)
+    console.log('WEBHOOK_URL: ', WEBHOOK_URL)
+    console.log('WEBHOOK_TOKEN: ', WEBHOOK_TOKEN)
+    console.log('WEBHOOK_INTERVAL: ', WEBHOOK_INTERVAL)
+
+    if (!REDIS_URL) {
+      console.error('REDIS_URL is not defined')
+      process.exit(1)
+    }
   }
 
   __asyncCrawl(req: express.Request, res: express.Response) {
@@ -32,6 +55,8 @@ class Server {
   }
 
   async __syncCrawl(req: express.Request, res: express.Response) {
+    await Webhook.get().started(req.body)
+
     const sender = new Sender(req.body)
     await sender.init()
 
@@ -39,7 +64,13 @@ class Server {
 
     await crawler.run()
     await sender.finish()
+    await Webhook.get().completed(req.body)
     res.send('Crawling finished')
+  }
+
+  async __log_webhook(req: express.Request, res: express.Response) {
+    console.log("webhook received: ", req.body)
+    res.send('ok')
   }
 }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -30,12 +30,8 @@ class Server {
   }
 
   __check_env() {
-    const {
-      REDIS_URL,
-      WEBHOOK_URL,
-      WEBHOOK_TOKEN,
-      WEBHOOK_INTERVAL
-    } = process.env;
+    const { REDIS_URL, WEBHOOK_URL, WEBHOOK_TOKEN, WEBHOOK_INTERVAL } =
+      process.env
 
     console.log('REDIS_URL: ', REDIS_URL)
     console.log('WEBHOOK_URL: ', WEBHOOK_URL)
@@ -68,8 +64,8 @@ class Server {
     res.send('Crawling finished')
   }
 
-  async __log_webhook(req: express.Request, res: express.Response) {
-    console.log("webhook received: ", req.body)
+  __log_webhook(req: express.Request, res: express.Response) {
+    console.log('webhook received: ', req.body)
     res.send('ok')
   }
 }

--- a/src/taskQueue.ts
+++ b/src/taskQueue.ts
@@ -9,7 +9,7 @@ export default class TaskQueue {
   constructor() {
     console.info('TaskQueue::constructor')
     if (process.env.REDIS_URL) {
-      this.queue = new Queue('crawling', process.env.REDIS_URL!)
+      this.queue = new Queue('crawling', process.env.REDIS_URL)
     } else {
       this.queue = new Queue('crawling')
     }

--- a/src/taskQueue.ts
+++ b/src/taskQueue.ts
@@ -3,16 +3,13 @@ import { initMeilisearchClient } from './meilisearch_client.js'
 import { fork } from 'child_process'
 import { Config } from './types'
 
-const redis_url = process.env.REDIS_URL
-
 export default class TaskQueue {
   queue: Queue.Queue
 
   constructor() {
     console.info('TaskQueue::constructor')
-    console.log(redis_url)
-    if (redis_url) {
-      this.queue = new Queue('crawling', redis_url)
+    if (process.env.REDIS_URL) {
+      this.queue = new Queue('crawling', process.env.REDIS_URL!)
     } else {
       this.queue = new Queue('crawling')
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -19,6 +19,7 @@ export type Config = {
   urls_to_not_index?: string[]
   schema_settings?: SchemaSettings
   user_agents?: string[]
+  webhook_payload?: Record<string, any>
 }
 
 export type SchemaSettings = {

--- a/src/webhook.ts
+++ b/src/webhook.ts
@@ -1,26 +1,28 @@
-import axios, { AxiosResponse } from 'axios';
-import { Config } from './types';
+import axios, { AxiosResponse } from 'axios'
+import { Config } from './types'
 
 // This webhook sender is a singleton
 export class Webhook {
-  private static instance: Webhook;
+  private static instance: Webhook
 
-  configured: boolean = false
+  configured = false
 
   constructor() {
     console.info('Webhook::constructor')
     if (process.env.WEBHOOK_URL) {
       this.configured = true
     } else {
-      console.warn('Webhook not configured; if you want to use a webhook, set the WEBHOOK_URL environment variable')
+      console.warn(
+        'Webhook not configured; if you want to use a webhook, set the WEBHOOK_URL environment variable'
+      )
     }
   }
 
   public static get(): Webhook {
     if (!Webhook.instance) {
-      Webhook.instance = new Webhook();
+      Webhook.instance = new Webhook()
     }
-    return Webhook.instance;
+    return Webhook.instance
   }
 
   async started(config: Config) {
@@ -49,6 +51,7 @@ export class Webhook {
   }
 
   async __callWebhook(config: Config, data: any) {
+    if (!process.env.WEBHOOK_URL) return
     try {
       data.meilisearch_url = config.meilisearch_url
       data.meilisearch_index_uid = config.meilisearch_index_uid
@@ -56,17 +59,21 @@ export class Webhook {
       const date = new Date()
       data.date = date.toISOString()
 
-      let headers: Record<string, string> = {
+      const headers: Record<string, string> = {
         'Content-Type': 'application/json',
       }
 
       if (process.env.WEBHOOK_TOKEN) {
-        headers['Authorization'] = `Bearer ${process.env.WEBHOOK_TOKEN!}`
+        headers['Authorization'] = `Bearer ${process.env.WEBHOOK_TOKEN}`
       }
 
-      const response: AxiosResponse = await axios.post(process.env.WEBHOOK_URL!, data, {
-        headers: headers
-      })
+      const response: AxiosResponse = await axios.post(
+        process.env.WEBHOOK_URL,
+        data,
+        {
+          headers: headers,
+        }
+      )
       if (response.status == 401 || response.status == 403) {
         this.configured = false
       }

--- a/src/webhook.ts
+++ b/src/webhook.ts
@@ -30,7 +30,7 @@ export class Webhook {
     await this.__callWebhook(config, { status: 'started' })
   }
 
-  async active(config: Config, data: any) {
+  async active(config: Config, data: Record<string, any>) {
     if (!this.configured) return
     await this.__callWebhook(config, { status: 'active', ...data })
   }
@@ -40,9 +40,12 @@ export class Webhook {
     await this.__callWebhook(config, { status: 'paused' })
   }
 
-  async completed(config: Config) {
+  async completed(config: Config, nbDocumentsSent: number) {
     if (!this.configured) return
-    await this.__callWebhook(config, { status: 'completed' })
+    await this.__callWebhook(config, {
+      status: 'completed',
+      nb_documents_sent: nbDocumentsSent,
+    })
   }
 
   async failed(config: Config, error: Error) {
@@ -55,6 +58,10 @@ export class Webhook {
     try {
       data.meilisearch_url = config.meilisearch_url
       data.meilisearch_index_uid = config.meilisearch_index_uid
+
+      if (config.webhook_payload) {
+        data.webhook_payload = config.webhook_payload
+      }
 
       const date = new Date()
       data.date = date.toISOString()

--- a/src/webhook.ts
+++ b/src/webhook.ts
@@ -1,0 +1,77 @@
+import axios, { AxiosResponse } from 'axios';
+import { Config } from './types';
+
+// This webhook sender is a singleton
+export class Webhook {
+  private static instance: Webhook;
+
+  configured: boolean = false
+
+  constructor() {
+    console.info('Webhook::constructor')
+    if (process.env.WEBHOOK_URL) {
+      this.configured = true
+    } else {
+      console.warn('Webhook not configured; if you want to use a webhook, set the WEBHOOK_URL environment variable')
+    }
+  }
+
+  public static get(): Webhook {
+    if (!Webhook.instance) {
+      Webhook.instance = new Webhook();
+    }
+    return Webhook.instance;
+  }
+
+  async started(config: Config) {
+    if (!this.configured) return
+    await this.__callWebhook(config, { status: 'started' })
+  }
+
+  async active(config: Config, data: any) {
+    if (!this.configured) return
+    await this.__callWebhook(config, { status: 'active', ...data })
+  }
+
+  async paused(config: Config) {
+    if (!this.configured) return
+    await this.__callWebhook(config, { status: 'paused' })
+  }
+
+  async completed(config: Config) {
+    if (!this.configured) return
+    await this.__callWebhook(config, { status: 'completed' })
+  }
+
+  async failed(config: Config, error: Error) {
+    if (!this.configured) return
+    await this.__callWebhook(config, { status: 'failed', error: error.message })
+  }
+
+  async __callWebhook(config: Config, data: any) {
+    try {
+      data.meilisearch_url = config.meilisearch_url
+      data.meilisearch_index_uid = config.meilisearch_index_uid
+
+      const date = new Date()
+      data.date = date.toISOString()
+
+      let headers: Record<string, string> = {
+        'Content-Type': 'application/json',
+      }
+
+      if (process.env.WEBHOOK_TOKEN) {
+        headers['Authorization'] = `Bearer ${process.env.WEBHOOK_TOKEN!}`
+      }
+
+      const response: AxiosResponse = await axios.post(process.env.WEBHOOK_URL!, data, {
+        headers: headers
+      })
+      if (response.status == 401 || response.status == 403) {
+        this.configured = false
+      }
+    } catch (error) {
+      console.error('Error calling webhook:', error)
+    }
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -845,6 +845,15 @@ asynckit@^0.4.0:
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
   integrity sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==
 
+axios@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.4.0.tgz#38a7bf1224cd308de271146038b551d725f0be1f"
+  integrity sha512-S4XCWMEmzvo64T9GfvQDOXgYRDJ/wsSZc7Jvdgx5u1sd0JwsuPLqb3SYmusag+edF6ziyMensPVqLTSc1PiSEA==
+  dependencies:
+    follow-redirects "^1.15.0"
+    form-data "^4.0.0"
+    proxy-from-env "^1.1.0"
+
 balanced-match@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
@@ -1893,6 +1902,11 @@ flatted@^3.1.0:
   version "3.2.7"
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.2.7.tgz#609f39207cb614b89d0765b477cb2d437fbf9787"
   integrity sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==
+
+follow-redirects@^1.15.0:
+  version "1.15.2"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.2.tgz#b460864144ba63f2681096f274c4e57026da2c13"
+  integrity sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==
 
 form-data-encoder@1.7.2:
   version "1.7.2"


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #59, #5

## What does this PR do?
The PR adds the capacity to the scraper to send updates to a webhook. This takes three new env vars: 
- `WEBHOOK_URL` that is necessary to use the webhook. 
- `WEBHOOK_TOKEN` is optional but needed in case of a protected webhook URL. 
- `WEBHOOK_INTERVAL` is optional; the default value is 5000ms.

This PR also add a `/webhook` that logs the webhook bodies for test purpose. 

The `Webhook` handler works as a singleton. Here is some example of webhook bodies.

Started:
```json
{
  status: 'started',
  meilisearch_url: 'https://xxx.lon.meilisearch.io',
  meilisearch_index_uid: 'meilisearch_docs',
  date: '2023-07-23T10:05:58.768Z'
}
```

Active:
```json
{
  status: 'active',
  nb_page_crawled: 8,
  nb_page_indexed: 6,
  nb_documents_sent: 62,
  meilisearch_url: 'https://ms-c231a2ea8724-106.lon.meilisearch.io',
  meilisearch_index_uid: 'meilisearch_docs',
  date: '2023-07-23T10:06:04.335Z'
}
```

Completed:
```json
{
  status: 'completed',
  meilisearch_url: 'https://xxx.lon.meilisearch.io',
  meilisearch_index_uid: 'meilisearch_docs',
  date: '2023-07-23T09:56:10.951Z'
}
```