### PR TITLE
Build scrapix into a cjs module

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "doc-crawler-test",
+  "name": "scrapix",
   "version": "0.0.1",
-  "type": "module",
   "description": "This is an example of a Crawlee project.",
+  "main": "dist/src/index.js",
   "dependencies": {
     "bull": "^4.10.4",
     "crawlee": "^3.0.0",
@@ -18,7 +18,7 @@
   },
   "scripts": {
     "build": "tsc",
-    "start": "tsc && node dist/src/index.js",
+    "start": "tsc && node dist/src/bin/index.js",
     "serve": "tsc && node dist/src/server.js",
     "dev:build": "nodemon --config ./config/nodemon:build.json",
     "dev:ds:scrap": "nodemon --config ./config/nodemon:docsearch-scrap.json",

--- a/src/bin/index.ts
+++ b/src/bin/index.ts
@@ -1,0 +1,32 @@
+import * as dotenv from 'dotenv'
+dotenv.config()
+
+import fs from 'fs'
+import yargs from 'yargs'
+import { hideBin } from 'yargs/helpers'
+import { Sender } from '../sender.js'
+import { Crawler } from '../crawler.js'
+import { Config } from '../types.js'
+
+// eslint-disable-next-line @typescript-eslint/no-floating-promises
+;(async () => {
+  // Parse command line arguments and get a configuration file path
+  const argv = await yargs(hideBin(process.argv)).option('config', {
+    alias: 'c',
+    describe: 'Path to configuration file',
+    demandOption: true,
+    type: 'string',
+  }).argv
+
+  const config: Config = JSON.parse(
+    fs.readFileSync(argv.config, { encoding: 'utf-8' })
+  ) as Config
+
+  const sender = new Sender(config)
+  await sender.init()
+
+  const crawler = new Crawler(sender, config)
+
+  await crawler.run()
+  await sender.finish()
+})()

--- a/src/bin/index.ts
+++ b/src/bin/index.ts
@@ -4,9 +4,9 @@ dotenv.config()
 import fs from 'fs'
 import yargs from 'yargs'
 import { hideBin } from 'yargs/helpers'
-import { Sender } from '../sender.js'
-import { Crawler } from '../crawler.js'
-import { Config } from '../types.js'
+import { Sender } from '../sender'
+import { Crawler } from '../crawler'
+import { Config } from '../types'
 
 // eslint-disable-next-line @typescript-eslint/no-floating-promises
 ;(async () => {

--- a/src/crawler.ts
+++ b/src/crawler.ts
@@ -19,7 +19,7 @@ type DefaultHandler = Parameters<
 // This class is responsible for crawling the urls and extract content to send to Meilisearch
 // It uses the createPuppeteerRouter method to create a router that will be used by the PuppeteerCrawler.
 // The constructor take a Sender object as a parameter
-export default class Crawler {
+export class Crawler {
   sender: Sender
   config: Config
   urls: string[]

--- a/src/crawler.ts
+++ b/src/crawler.ts
@@ -5,11 +5,11 @@ import {
   PuppeteerCrawlingContext,
 } from 'crawlee'
 import { minimatch } from 'minimatch'
-import DefaultScraper from './scrapers/default.js'
-import DocsearchScraper from './scrapers/docssearch.js'
-import SchemaScraper from './scrapers/schema.js'
-import { Sender } from './sender.js'
-import { Config, Scraper } from './types.js'
+import DefaultScraper from './scrapers/default'
+import DocsearchScraper from './scrapers/docssearch'
+import SchemaScraper from './scrapers/schema'
+import { Sender } from './sender'
+import { Config, Scraper } from './types'
 
 type DefaultHandler = Parameters<
   Parameters<Router<PuppeteerCrawlingContext>['addDefaultHandler']>[0]

--- a/src/crawler_process.ts
+++ b/src/crawler_process.ts
@@ -1,5 +1,5 @@
 import { Sender } from './sender.js'
-import Crawler from './crawler.js'
+import { Crawler } from './crawler.js'
 import { Config } from './types.js'
 
 async function startCrawling(config: Config) {

--- a/src/crawler_process.ts
+++ b/src/crawler_process.ts
@@ -1,6 +1,6 @@
-import { Sender } from './sender.js'
-import { Crawler } from './crawler.js'
-import { Config } from './types.js'
+import { Sender } from './sender'
+import { Crawler } from './crawler'
+import { Config } from './types'
 
 async function startCrawling(config: Config) {
   const sender = new Sender(config)

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,29 +1,3 @@
-import * as dotenv from 'dotenv'
-dotenv.config()
-
-import fs from 'fs'
-import yargs from 'yargs'
-import { hideBin } from 'yargs/helpers'
-import { Sender } from './sender.js'
-import Crawler from './crawler.js'
-import { Config } from './types.js'
-
-// Parse command line arguments and get a configuration file path
-const argv = await yargs(hideBin(process.argv)).option('config', {
-  alias: 'c',
-  describe: 'Path to configuration file',
-  demandOption: true,
-  type: 'string',
-}).argv
-
-const config: Config = JSON.parse(
-  fs.readFileSync(argv.config, { encoding: 'utf-8' })
-) as Config
-
-const sender = new Sender(config)
-await sender.init()
-
-const crawler = new Crawler(sender, config)
-
-await crawler.run()
-await sender.finish()
+export { Crawler } from './crawler'
+export { Sender } from './sender'
+export { TaskQueue } from './taskQueue'

--- a/src/meilisearch_client.ts
+++ b/src/meilisearch_client.ts
@@ -1,5 +1,5 @@
 import { Config, MeiliSearch } from 'meilisearch'
-import { PACKAGE_VERSION } from './package_version.js'
+import { PACKAGE_VERSION } from './package_version'
 
 export function initMeilisearchClient({
   host,

--- a/src/scrapers/default.ts
+++ b/src/scrapers/default.ts
@@ -1,6 +1,6 @@
 import prettier from 'prettier'
 import { v4 as uuidv4 } from 'uuid'
-import { Sender } from '../sender.js'
+import { Sender } from '../sender'
 import { Config, Meta, DefaultDocument } from '../types'
 import { Page } from 'puppeteer'
 

--- a/src/scrapers/docssearch.ts
+++ b/src/scrapers/docssearch.ts
@@ -1,5 +1,5 @@
 import { v4 as uuidv4 } from 'uuid'
-import { Sender } from '../sender.js'
+import { Sender } from '../sender'
 import { Page } from 'puppeteer'
 import {
   DocsSearchDocument,

--- a/src/scrapers/schema.ts
+++ b/src/scrapers/schema.ts
@@ -1,7 +1,7 @@
 import { v4 as uuidv4 } from 'uuid'
 import { Page } from 'puppeteer'
-import { Sender } from '../sender.js'
-import { Config, SchemaDocument } from '../types.js'
+import { Sender } from '../sender'
+import { Config, SchemaDocument } from '../types'
 
 export default class SchemaScaper {
   sender: Sender

--- a/src/sender.ts
+++ b/src/sender.ts
@@ -1,6 +1,6 @@
 import { MeiliSearch, Settings } from 'meilisearch'
 import { Config, DocumentType } from './types'
-import { initMeilisearchClient } from './meilisearch_client.js'
+import { initMeilisearchClient } from './meilisearch_client'
 
 //Create a class called Sender that will queue the json data and batch it to a Meilisearch instance
 export class Sender {

--- a/src/server.ts
+++ b/src/server.ts
@@ -2,9 +2,9 @@ import * as dotenv from 'dotenv'
 dotenv.config()
 
 import express from 'express'
-import { TaskQueue } from './taskQueue.js'
-import { Sender } from './sender.js'
-import { Crawler } from './crawler.js'
+import { TaskQueue } from './taskQueue'
+import { Sender } from './sender'
+import { Crawler } from './crawler'
 
 const port = process.env.PORT || 8080
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -2,9 +2,9 @@ import * as dotenv from 'dotenv'
 dotenv.config()
 
 import express from 'express'
-import TaskQueue from './taskQueue.js'
+import { TaskQueue } from './taskQueue.js'
 import { Sender } from './sender.js'
-import Crawler from './crawler.js'
+import { Crawler } from './crawler.js'
 
 const port = process.env.PORT || 8080
 

--- a/src/taskQueue.ts
+++ b/src/taskQueue.ts
@@ -1,5 +1,5 @@
 import Queue, { Job, DoneCallback } from 'bull'
-import { initMeilisearchClient } from './meilisearch_client.js'
+import { initMeilisearchClient } from './meilisearch_client'
 import { fork } from 'child_process'
 import { Config } from './types'
 

--- a/src/taskQueue.ts
+++ b/src/taskQueue.ts
@@ -5,7 +5,7 @@ import { Config } from './types'
 
 const redis_url = process.env.REDIS_URL
 
-export default class TaskQueue {
+export class TaskQueue {
   queue: Queue.Queue
 
   constructor() {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,7 @@
 import { Settings } from 'meilisearch'
-import DocsearchScraper from './scrapers/docssearch.js'
-import DefaultScraper from './scrapers/default.js'
-import SchemaScraper from './scrapers/schema.js'
+import DocsearchScraper from './scrapers/docssearch'
+import DefaultScraper from './scrapers/default'
+import SchemaScraper from './scrapers/schema'
 
 export type Config = {
   meilisearch_index_uid: string

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "@apify/tsconfig",
   "compilerOptions": {
-    "module": "ES2022",
+    "module": "CommonJS",
     "target": "ES2022",
     "outDir": "./dist/src",
     "allowJs": true,
@@ -9,7 +9,5 @@
     "esModuleInterop": true
   },
   "include": ["src/**/*"],
-  "exclude": [
-    "node_modules"
-  ]
+  "exclude": ["node_modules"]
 }


### PR DESCRIPTION
Currently, upon building scrapix, the target was in ES. Natively, node environment cannot run it. Which made using scrapix in a node environment complicated.

