### PR TITLE
Add webhook_url as a config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,9 @@ Meilisearch JS (vx.x.x); Meilisearch Crawler (vx.x.x); My Thing (vx.x.x)
 `webhook_payload`
 In the case [webhooks](#webhooks) are enabled, the webhook_payload option gives the possibility to provide information that will be added in the webhook payload.
 
+`webhook_url`
+The URL on which the webhook calls are made.
+
 ## Webhooks
 
 To be able to receive updates on the state of the crawler, you need to create a webhook. To do so, you absolutely need to have a public URL that can be reached by the crawler. This URL will be called by the crawler to send you updates.

--- a/src/crawler.ts
+++ b/src/crawler.ts
@@ -81,7 +81,7 @@ export class Crawler {
     }
 
     const intervalId = setInterval(async () => {
-      await Webhook.get().active(this.config, {
+      await Webhook.get(this.config).active(this.config, {
         nb_page_crawled: this.nb_page_crawled,
         nb_page_indexed: this.nb_page_indexed,
         nb_documents_sent: this.sender.nb_documents_sent,
@@ -91,13 +91,13 @@ export class Crawler {
     try {
       await this.crawler.run(this.urls)
 
-      await Webhook.get().active(this.config, {
+      await Webhook.get(this.config).active(this.config, {
         nb_page_crawled: this.nb_page_crawled,
         nb_page_indexed: this.nb_page_indexed,
         nb_documents_sent: this.sender.nb_documents_sent,
       })
     } catch (err) {
-      await Webhook.get().failed(this.config, err as Error)
+      await Webhook.get(this.config).failed(this.config, err as Error)
     } finally {
       clearInterval(intervalId)
     }

--- a/src/sender.ts
+++ b/src/sender.ts
@@ -1,7 +1,7 @@
 import { MeiliSearch, Settings } from 'meilisearch'
 import { Config, DocumentType } from './types'
 import { initMeilisearchClient } from './meilisearch_client'
-import { Webhook } from './webhook.js'
+import { Webhook } from './webhook'
 
 //Create a class called Sender that will queue the json data and batch it to a Meilisearch instance
 export class Sender {
@@ -31,7 +31,7 @@ export class Sender {
   async init() {
     console.log('Sender::init')
     try {
-      await Webhook.get().started(this.config)
+      await Webhook.get(this.config).started(this.config)
       const index = await this.client.getIndex(this.initial_index_uid)
 
       if (index) {
@@ -93,7 +93,10 @@ export class Sender {
       await this.client.index(this.index_uid).waitForTask(task.taskUid)
     }
 
-    await Webhook.get().completed(this.config, this.nb_documents_sent)
+    await Webhook.get(this.config).completed(
+      this.config,
+      this.nb_documents_sent
+    )
   }
 
   async __batchSend() {

--- a/src/types.ts
+++ b/src/types.ts
@@ -20,6 +20,7 @@ export type Config = {
   schema_settings?: SchemaSettings
   user_agents?: string[]
   webhook_payload?: Record<string, any>
+  webhook_url?: string
 }
 
 export type SchemaSettings = {


### PR DESCRIPTION
Having only one `WEBHOOK_URL` provided by an environment variable brought to many limitations.

The cloud is using scrapix through a lambda, ENV variables in lambda must be set on create or update. They cannot be changed when they are invoked.

This led to not being able to change the webhook URL to `cloud.meilisearch.dev` or `.com` depending on the environment.

Additionally, having the webhook_url as an option provides the possibility to create a dedicated route for a dedicated project and index.

for example

```
/v1/api/v1/projects/:projectId/indexes/:index/webhook
```

Which means we do not have to pass the information of the project id and the index through the `webhook_payload` configuration.

New configuration:
```
wehbook_url: "myurl.com"
```