### PR TITLE
Only package src and dist

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meilisearch/scrapix",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Automatic scraper and indexer to Meilisearch of any website.",
   "main": "dist/src/index.js",
   "dependencies": {
@@ -50,5 +50,9 @@
     "eslint-plugin-prettier": "^4.2.1",
     "nodemon": "^2.0.22",
     "typescript": "^5.1.3"
-  }
+  },
+  "files": [
+    "dist",
+    "src"
+  ]
 }

--- a/src/package_version.ts
+++ b/src/package_version.ts
@@ -1,1 +1,1 @@
-export const PACKAGE_VERSION = '0.1.0'
+export const PACKAGE_VERSION = '0.1.1'


### PR DESCRIPTION
The npm package contained all directories from this repository. Including the very heavy `playground` folder.

It will now only build `src/` `dist/` dans the ones npm publishes by default `package.json` etc