### PR TITLE
Change temporary indexname to _crawler_tmp instead of _tmp

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ For each scrappable page it will scrape the data by trying to create blocks of t
 ### 3. Send the data to Meilisearch
 
 While the worker is scraping the website it will send the data to Meilisearch by batch.
-Before sending the data to Meilisearch, it will create a new index called `{index_uid}_tmp`, apply the settings and add the data to it. Then it will use the index swap method to replace the old index by the new one. It will finish properly by deleting the tmp index.
+Before sending the data to Meilisearch, it will create a new index called `{index_uid}_crawler_tmp`, apply the settings and add the data to it. Then it will use the index swap method to replace the old index by the new one. It will finish properly by deleting the tmp index.
 
 The setting applied:
 

--- a/src/sender.ts
+++ b/src/sender.ts
@@ -35,7 +35,7 @@ export class Sender {
       const index = await this.client.getIndex(this.initial_index_uid)
 
       if (index) {
-        this.index_uid = this.initial_index_uid + '_tmp'
+        this.index_uid = this.initial_index_uid + '_crawler_tmp'
 
         const tmp_index = await this.client.getIndex(this.index_uid)
         if (tmp_index) {

--- a/src/taskQueue.ts
+++ b/src/taskQueue.ts
@@ -54,7 +54,7 @@ export class TaskQueue {
     })
 
     //check if the tmp index exists
-    const tmp_index_uid = job.data.meilisearch_index_uid + '_tmp'
+    const tmp_index_uid = job.data.meilisearch_index_uid + '_crawler_tmp'
     try {
       const index = await client.getIndex(tmp_index_uid)
       if (index) {


### PR DESCRIPTION
# Pull Request

## What does this PR do?
`_tmp` might be to common as an index naming and is not providing enough context for the user to understand this is a tmp index for the crawler specifically.