### PR TITLE
Increases timeout to avoid MeiliSearchTimeOutError when using auto-embeddings

### DIFF
--- a/src/sender.ts
+++ b/src/sender.ts
@@ -116,7 +116,7 @@ export class Sender {
     const task = await this.client
       .index(this.index_uid)
       .addDocuments(this.queue)
-    await this.client.waitForTask(task.taskUid)
+    await this.client.waitForTask(task.taskUid, { timeOutMs: 15000 })
   }
 
   async __swapIndex() {


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #91 

## What does this PR do?
- Increases waitForTask timeout in __batchSendSync()

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
