### PR TITLE
add configuration option for additional request headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,19 @@ In the case [webhooks](#webhooks) are enabled, the webhook_payload option gives 
 `webhook_url`
 The URL on which the webhook calls are made.
 
+`additional_request_headers`
+An object containing headers to be added to every request the crawler makes.
+This can be useful to add authentication headers to crawl protected sites.
+
+E.g. authenticate crawler with basic auth:
+```
+{
+  "additional_request_headers": {
+    "Authorization": "Basic dXNlcjpwYXNzd29yZA=="
+  }
+}
+```
+
 ## Webhooks
 
 To be able to receive updates on the state of the crawler, you need to create a webhook. To do so, you absolutely need to have a public URL that can be reached by the crawler. This URL will be called by the crawler to send you updates.

--- a/src/crawler.ts
+++ b/src/crawler.ts
@@ -51,8 +51,8 @@ export class Crawler {
       this.config.strategy == 'docssearch'
         ? new DocsearchScraper(this.sender, this.config)
         : this.config.strategy == 'schema'
-          ? new SchemaScraper(this.sender, this.config)
-          : new DefaultScraper(this.sender, this.config)
+        ? new SchemaScraper(this.sender, this.config)
+        : new DefaultScraper(this.sender, this.config)
   }
 
   async run() {
@@ -63,22 +63,26 @@ export class Crawler {
     //Create the router
     const router = createPuppeteerRouter()
 
-
     // type DefaultHandler = Parameters<typeof router.addDefaultHandler>[0];
     router.addDefaultHandler(this.defaultHandler.bind(this))
 
-    const preNavigationHooks: PuppeteerHook[] = this.config.additional_request_headers ? [
-      async (crawlingContext) => {
-        crawlingContext.addInterceptRequestHandler(async (request) => {
-          request.continue({
-            headers: {
-              ...request.headers(),
-              ...this.config.additional_request_headers,
-            }
-          });
-        })
-      },
-    ] : []
+    const preNavigationHooks: PuppeteerHook[] = this.config
+      .additional_request_headers
+      ? [
+          async (crawlingContext) => {
+            await crawlingContext.addInterceptRequestHandler(
+              async (request) => {
+                return await request.continue({
+                  headers: {
+                    ...request.headers(),
+                    ...this.config.additional_request_headers,
+                  },
+                })
+              }
+            )
+          },
+        ]
+      : []
 
     const puppeteerCrawlerOptions: PuppeteerCrawlerOptions = {
       requestQueue,

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,6 +9,7 @@ export type Config = {
   meilisearch_api_key: string
   start_urls: string[]
   urls_to_exclude?: string[]
+  additional_request_headers?: Record<string, string>
   queue?: string[]
   primary_key?: string
   batch_size?: number


### PR DESCRIPTION
# Pull Request

## Related issue
none

## What does this PR do?
We're using scrapix to index our documentation.
Some parts of the documentation are protected, so we need a way to send some authentication information with the crawler requests.
This PR adds a new configuration property `additional_request_headers` which are applied to each request in a pre navigation hook.
This way we're able to either send an `Authorization` header (basic, bearer etc.) or a custom auth header (e.g. `x-access-key`), so it should be quite flexible for any usecase.

- add configuration option for additional_request_headers
- add a pre navigation hook to add those headers to the request
